### PR TITLE
Create a NoOp for cmd.Execute

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -20,6 +20,9 @@ type Option func(Cmd) error
 // to every cmd.Exec call
 var globalOpts []Option
 
+// AddGlobalOption adds an option to EVERY call
+// to Execute. the caller to Execute can overwrite
+// options, as they are evaluated afterwards.
 func AddGlobalOptions(opts ...Option) {
 	globalOpts = append(globalOpts, opts...)
 }

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -10,6 +10,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGlobalOpts(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	AddGlobalOptions(WorkingDir(tmpDir))
+
+	out, err := Execute([]string{"sh", "-c", "'pwd'"})
+	// cannot directly compare output as on MacOS, TempDir returns /var/...,
+	// while the actual directory is reported as /private/var/...
+	assert.True(t, strings.HasSuffix(out, tmpDir+"\n"))
+	assert.NoError(t, err)
+
+	// reset
+	ResetGlobalOptions()
+}
+
 func TestExpand(t *testing.T) {
 	usr, err := user.Current()
 	assert.NoError(t, err)
@@ -46,7 +62,7 @@ func TestExec(t *testing.T) {
 	assert.True(t, strings.HasSuffix(out, tmpDir+"\n"))
 	assert.NoError(t, err)
 
-	out, err = Execute([]string{"false"}, DirectPrint(false))
+	out, err = Execute([]string{"false"})
 	assert.Equal(t, "", out)
 	assert.Error(t, err)
 

--- a/test/fake/cmd.go
+++ b/test/fake/cmd.go
@@ -1,0 +1,28 @@
+package fake
+
+import (
+	"fmt"
+
+	"github.com/tommyknows/packa/pkg/cmd"
+)
+
+// NoOp makes cmd.Exec not execute the actual command, but rather
+// just print the output given (adding a newline). Writes the command that would have
+// been executed into the channel
+func NoOp(cmds chan []string, output string) func(cmd.Cmd) error {
+	return func(command cmd.Cmd) error {
+		cmds <- command.Args
+		command.Args = []string{"echo", output}
+		command.Path = "/bin/echo"
+		return nil
+	}
+}
+
+func NoOpError(cmds chan []string, output string) func(cmd.Cmd) error {
+	return func(command cmd.Cmd) error {
+		cmds <- command.Args
+		command.Args = []string{"sh", "-c", fmt.Sprintf("echo \"%v\" && false", output)}
+		command.Path = "/bin/sh"
+		return nil
+	}
+}

--- a/test/fake/cmd.go
+++ b/test/fake/cmd.go
@@ -6,9 +6,9 @@ import (
 	"github.com/tommyknows/packa/pkg/cmd"
 )
 
-// NoOp makes cmd.Exec not execute the actual command, but rather
-// just print the output given (adding a newline). Writes the command that would have
-// been executed into the channel
+// NoOp makes cmd.Exec not execute the actual command, but rather just print the
+// given output (adding a newline). Writes the command that would have been executed
+// into the channel
 func NoOp(cmds chan []string, output string) func(cmd.Cmd) error {
 	return func(command cmd.Cmd) error {
 		cmds <- command.Args
@@ -18,6 +18,8 @@ func NoOp(cmds chan []string, output string) func(cmd.Cmd) error {
 	}
 }
 
+// NoOpError acts the same as NooOp, but will make the command exit with a non-zero
+// exit code.
 func NoOpError(cmds chan []string, output string) func(cmd.Cmd) error {
 	return func(command cmd.Cmd) error {
 		cmds <- command.Args

--- a/test/fake/cmd_test.go
+++ b/test/fake/cmd_test.go
@@ -1,0 +1,38 @@
+package fake
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tommyknows/packa/pkg/cmd"
+)
+
+func TestNoOpCmd(t *testing.T) {
+	executedCommand := make(chan []string, 1)
+	output := "testoutput"
+
+	out, err := cmd.Execute([]string{"echo", "hello world"}, NoOp(executedCommand, output))
+	assert.Equal(t, output+"\n", out)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"echo", "hello world"}, <-executedCommand)
+
+	// set the global options
+	cmd.AddGlobalOptions(NoOp(executedCommand, output))
+	//cmd.GlobalOpts = []cmd.Option{NoOp(executedCommand, output)}
+
+	out, err = cmd.Execute([]string{"echo", "hello world"})
+	assert.Equal(t, output+"\n", out)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"echo", "hello world"}, <-executedCommand)
+	cmd.ResetGlobalOptions()
+}
+
+func TestNoOpErrorCmd(t *testing.T) {
+	executedCommand := make(chan []string, 1)
+	output := "testoutput"
+
+	out, err := cmd.Execute([]string{"echo", "hello world"}, NoOpError(executedCommand, output))
+	assert.Equal(t, output+"\n", out)
+	assert.Error(t, err)
+	assert.Equal(t, []string{"echo", "hello world"}, <-executedCommand)
+}


### PR DESCRIPTION
This PR implements a NoOp option for `cmd.Execute` to be able to test and fake commands