### PR TITLE
truncate config file before writing new config

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -91,8 +91,7 @@ func (cfg *Configuration) save() error {
 		return errors.Wrapf(err, "could not marshal config file")
 	}
 
-	err = f.Truncate(0)
-	if err != nil {
+	if err = f.Truncate(0); err != nil {
 		return errors.Wrapf(err, "could not clear config file to overwrite")
 	}
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -91,6 +91,12 @@ func (cfg *Configuration) save() error {
 		return errors.Wrapf(err, "could not marshal config file")
 	}
 
+	err = f.Truncate(0)
+	if err != nil {
+		return errors.Wrapf(err, "could not clear config file to overwrite")
+	}
+
+	_, _ = f.Seek(0, 0)
 	bw, err := f.Write(enc)
 	if err != nil {
 		return errors.Wrapf(err, "could not write config file")


### PR DESCRIPTION
This commit fixes #6. 
If packages are removed, the config file gets
shorter. So far, we simply overwrote the config / state file, which
resulted in garbage at the end of the new content, which was related
to the old content.
To fix this, we now truncate (clear) the file before writing the
new contents to the file.